### PR TITLE
Meta keywords + descriptions management are moved from metaableinterface to node and site

### DIFF
--- a/ModelInterface/Model/MetaableInterface.php
+++ b/ModelInterface/Model/MetaableInterface.php
@@ -8,26 +8,6 @@ namespace OpenOrchestra\ModelInterface\Model;
 interface MetaableInterface
 {
     /**
-     * @param string $metaKeywords
-     */
-    public function setMetaKeywords($metaKeywords);
-
-    /**
-     * @return string
-     */
-    public function getMetaKeywords();
-
-    /**
-     * @param string $metaDescription
-     */
-    public function setMetaDescription($metaDescription);
-
-    /**
-     * @return string
-     */
-    public function getMetaDescription();
-
-    /**
      * @param boolean $metaIndex
      */
     public function setMetaIndex($metaIndex);

--- a/ModelInterface/Model/NodeInterface.php
+++ b/ModelInterface/Model/NodeInterface.php
@@ -193,4 +193,13 @@ interface NodeInterface extends ReadNodeInterface, BlockContainerInterface, Stat
      */
     public function getBoDirection();
 
+    /**
+     * @param string $metaKeywords
+     */
+    public function setMetaKeywords($metaKeywords);
+
+    /**
+     * @param string $metaDescription
+     */
+    public function setMetaDescription($metaDescription);
 }

--- a/ModelInterface/Model/ReadNodeInterface.php
+++ b/ModelInterface/Model/ReadNodeInterface.php
@@ -88,4 +88,14 @@ interface ReadNodeInterface extends TimestampableInterface, ReadSitemapableInter
      * @return int
      */
     public function getOrder();
+
+    /**
+     * @return string
+     */
+    public function getMetaKeywords();
+
+    /**
+     * @return string
+     */
+    public function getMetaDescription();
 }

--- a/ModelInterface/Model/ReadSiteInterface.php
+++ b/ModelInterface/Model/ReadSiteInterface.php
@@ -48,6 +48,30 @@ interface ReadSiteInterface extends MetaableInterface, ReadSitemapableInterface
     public function getTheme();
 
     /**
+     * @return string
+     */
+    public function getMetaKeywords();
+
+    /**
+     * @param string $language
+     *
+     * @return string
+     */
+    public function getMetaKeywordsInLanguage($language);
+
+    /**
+     * @return string
+     */
+    public function getMetaDescriptions();
+
+    /**
+     * @param string $language
+     *
+     * @return string
+     */
+    public function getMetaDescriptionInLanguage($language);
+
+    /**
      * Get robotsTxt
      *
      * @return string $robotsTxt

--- a/ModelInterface/Model/SiteInterface.php
+++ b/ModelInterface/Model/SiteInterface.php
@@ -59,6 +59,38 @@ interface SiteInterface extends ReadSiteInterface, SitemapableInterface, SoftDel
     public function setTheme(ThemeInterface $theme);
 
     /**
+     * @param array $metaKeywords
+     */
+    public function setMetaKeywords(array $metaKeywords);
+
+    /**
+     * @param string $language
+     * @param string $metaKeywords
+     */
+    public function addMetaKeywords($language, $metaKeywords);
+
+    /**
+     * @param string $language
+     */
+    public function removeMetaKeywords($language);
+
+    /**
+     * @param array $metaDescriptions
+     */
+    public function setMetaDescriptions(array $metaDescriptions);
+
+    /**
+     * @param string $language
+     * @param string $metaDescription
+     */
+    public function addMetaDescription($language, $metaDescription);
+
+    /**
+     * @param string $language
+     */
+    public function removeMetaDescription($language);
+
+    /**
      * Set robotsTxt
      *
      * @param string $robotsTxt

--- a/ModelInterface/Model/SitemapableInterface.php
+++ b/ModelInterface/Model/SitemapableInterface.php
@@ -3,7 +3,7 @@
 namespace OpenOrchestra\ModelInterface\Model;
 
 /**
- * interface MetaableInterface
+ * interface SitemapableInterface
  */
 interface SitemapableInterface extends ReadSitemapableInterface
 {


### PR DESCRIPTION
[OO-BCBREAK] Meta keywords and descriptions management are moved from metaableinterface to node (single language) and site (multi-languages) interfaces
https://github.com/open-orchestra/open-orchestra-model-interface/pull/195
https://github.com/open-orchestra/open-orchestra-mongo-libs/pull/33
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/595
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1757
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/171