### PR TITLE
1.1 fix content pagination count

### DIFF
--- a/ModelInterface/Repository/ContentRepositoryInterface.php
+++ b/ModelInterface/Repository/ContentRepositoryInterface.php
@@ -110,16 +110,41 @@ interface ContentRepositoryInterface extends ReadContentRepositoryInterface, Sta
      * @param string|null         $contentType
      * @param FinderConfiguration $configuration
      *
-     * @return array
+     * @return int
+     *
+     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersionWithFilter
      */
     public function countByContentTypeInLastVersionWithFilter($contentType = null, FinderConfiguration $configuration = null);
+
+    /**
+     * @param string|null         $contentType
+     * @param FinderConfiguration $configuration
+     * @param string|null         $siteId
+     *
+     * @return int
+     */
+    public function countByContentTypeAndSiteInLastVersionWithFilter(
+        $contentType = null,
+        FinderConfiguration $configuration = null,
+        $siteId = null
+    );
 
     /**
      * @param string|null $contentType
      *
      * @return int
+     *
+     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersion
      */
     public function countByContentTypeInLastVersion($contentType = null);
+
+    /**
+     * @param string|null $contentType
+     * @param string|null $siteId
+     *
+     * @return int
+     */
+    public function countByContentTypeAndSiteInLastVersion($contentType = null, $siteId = null);
 
     /**
      * @param string       $author
@@ -127,7 +152,7 @@ interface ContentRepositoryInterface extends ReadContentRepositoryInterface, Sta
      * @param int|null     $limit
      *
      * @return array
-     * 
+     *
      * @deprecated will be removed in 1.2.0
      */
     public function findByAuthor($author, $published = null, $limit = null);

--- a/ModelInterface/Repository/ContentRepositoryInterface.php
+++ b/ModelInterface/Repository/ContentRepositoryInterface.php
@@ -107,44 +107,30 @@ interface ContentRepositoryInterface extends ReadContentRepositoryInterface, Sta
     public function findPaginatedLastVersionByContentTypeAndSite($contentType = null, PaginateFinderConfiguration $configuration = null, $siteId = null);
 
     /**
-     * @param string|null         $contentType
+     * @param null                $contentType
      * @param FinderConfiguration $configuration
-     *
-     * @return int
-     *
-     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersionWithFilter
-     */
-    public function countByContentTypeInLastVersionWithFilter($contentType = null, FinderConfiguration $configuration = null);
-
-    /**
-     * @param string|null         $contentType
-     * @param FinderConfiguration $configuration
-     * @param string|null         $siteId
+     * @param int|null            $siteId
      *
      * @return int
      */
-    public function countByContentTypeAndSiteInLastVersionWithFilter(
-        $contentType = null,
-        FinderConfiguration $configuration = null,
-        $siteId = null
-    );
+    public function countByContentTypeInLastVersionWithFilter($contentType, FinderConfiguration $configuration = null, $siteId = null);
 
     /**
      * @param string|null $contentType
      *
      * @return int
      *
-     * @deprecated will be removed in 1.3.0, use countByContentTypeAndSiteInLastVersion
+     * @deprecated will be removed in 2.0, use countByContentTypeAndSiteInLastVersion
      */
     public function countByContentTypeInLastVersion($contentType = null);
 
     /**
-     * @param string|null $contentType
+     * @param string      $contentType
      * @param string|null $siteId
      *
      * @return int
      */
-    public function countByContentTypeAndSiteInLastVersion($contentType = null, $siteId = null);
+    public function countByContentTypeAndSiteInLastVersion($contentType, $siteId = null);
 
     /**
      * @param string       $author


### PR DESCRIPTION
[OO-BUGFIX] Fix elements count in content pagination.
[OO-DEPRECATED] ContentRepositoryInterface::countByContentTypeInLastVersion method is deprecated since version 1.1.3 and will be removed in 2.0, it is replace by ContentRepository::countByContentTypeAndSiteInLastVersion method.

https://github.com/open-orchestra/open-orchestra-model-interface/pull/212
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/621
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1825