### PR TITLE
update method to count content with site filter

### DIFF
--- a/ModelInterface/Repository/ContentRepositoryInterface.php
+++ b/ModelInterface/Repository/ContentRepositoryInterface.php
@@ -67,17 +67,27 @@ interface ContentRepositoryInterface extends ReadContentRepositoryInterface, Sta
     /**
      * @param string|null         $contentType
      * @param FinderConfiguration $configuration
+     * @param int|null            $siteId
      *
-     * @return array
+     * @return int
      */
-    public function countByContentTypeInLastVersionWithFilter($contentType = null, FinderConfiguration $configuration = null);
+    public function countByContentTypeInLastVersionWithFilter($contentType, FinderConfiguration $configuration = null, $siteId = null);
 
     /**
      * @param string|null $contentType
      *
      * @return int
+     * @deprecated will be removed in 2.0, use countByContentTypeAndSiteInLastVersion
      */
     public function countByContentTypeInLastVersion($contentType = null);
+
+    /**
+     * @param string      $contentType
+     * @param string|null $siteId
+     *
+     * @return int
+     */
+    public function countByContentTypeAndSiteInLastVersion($contentType, $siteId = null);
 
     /**
      * @param string       $author


### PR DESCRIPTION
[OO-BUGFIX] Fix elements count in content pagination.
[OO-DEPRECATED] ContentRepositoryInterface::countByContentTypeInLastVersion method is deprecated since version 1.1.3 and will be removed in 2.0, it is replace by ContentRepository::countByContentTypeAndSiteInLastVersion method.

cherry-pick https://github.com/open-orchestra/open-orchestra-model-interface/pull/212

https://github.com/open-orchestra/open-orchestra-model-bundle/pull/623
https://github.com/open-orchestra/open-orchestra-model-interface/pull/213
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1829
https://github.com/open-orchestra/open-orchestra/pull/1001